### PR TITLE
Change, damit der Vizit Viewer auch wieder geschlossen wird

### DIFF
--- a/Einbindung eines anderen Viewers - Vizit/imageViewer_vizit.js
+++ b/Einbindung eines anderen Viewers - Vizit/imageViewer_vizit.js
@@ -36,7 +36,42 @@ var Template_imageViewer_vizit = (function (_super) {
                         Vizit.Essential.Manager.Open("centerVizit", itemObject);
                         
                         // Der Vizit Viewer wird standardmäßig mit einem für das center zu geringem z-Index dargestellt
-                        $(".x-panel").css({ zIndex: 10});
+                        $(".x-panel").css({ zIndex: 10 });
+
+                        // um den Viewer zu beenden, wenn eine Unterstruktur ausgewählt wird (z.B. Eingangsrechnung --> WF-Protokoll)
+                        $(".k-tabstrip-items > li").each(function () {
+                            $(this).on("click", function () {
+                                Vizit.Essential.Manager.Clear();
+                            });
+                        });
+                        // END
+
+                        // um den Viewer zu beenden, wenn man sich in der Ordner-Ansicht befindet
+                        if ($(".folderContentInner").length) {
+                            // linke Navigations-Links
+                            $(".folderPlan > div").each(function () {
+                                if ($(this).hasClass("folder")) {
+                                    if (!$(this).hasClass("active")) {
+                                        $(this).on("click", function () {
+                                            Vizit.Essential.Manager.Clear();
+                                        });
+                                    }
+                                } else {
+                                    // Aktendeckel hat ander Funktionalität
+                                    $(".text", this).on("click", function () {
+                                        Vizit.Essential.Manager.Clear();
+                                    });
+                                }
+                            });
+
+                            // History
+                            $(".historyInner > .outer > .inner > div").each(function () {
+                                $(this).on("click", function () {
+                                    Vizit.Essential.Manager.Clear();
+                                });
+                            });
+                        }
+                        // END
                     
                         dfd.resolve();
                     }


### PR DESCRIPTION
Nach diversen Tests ist mir aufgefallen, dass es zu Problemen kommt, wenn der Vizit-Viewer offen ist und in andere Bereiche navigiert wird. Dann bleibt der Viewer offen und überdeckt sehr oft die interessanten Bereiche.
Mit diesem Code, habe ich einen Workaround gefunden.
